### PR TITLE
NOREF Convert column names to camelCase

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -18,7 +18,7 @@ def init
     username: ENV['DB_USERNAME'],
     password: password
   )
-  $db_fields = Hash.new { |h,k| h[k] = k.gsub(/([a-z])([^a-z])/){"#{$1}_#{$2.downcase}"}  }
+
   $kinesis_client = NYPLRubyUtil::KinesisClient.new(
     schema_string: ENV['SCHEMA_STRING'],
     stream_name: ENV['STREAM_NAME']

--- a/holding-schema.rb
+++ b/holding-schema.rb
@@ -4,35 +4,35 @@ def init_db
   ActiveRecord::Schema.define do
     create_table :records do |t|
       t.index :id, unique: true
-      t.integer :bib_ids, array: true, default: []
-      t.string :bib_id_links, array: true, default: []
-      t.integer :item_ids, array: true, default: []
-      t.string :item_id_links, array: true, default: []
-      t.boolean :inherit_location
-      t.string :allocation_rule
-      t.integer :accounting_unit
-      t.string :label_code
-      t.string :serial_code_1
-      t.string :serial_code_2
-      t.string :serial_code_3
-      t.string :serial_code_4
-      t.string :claim_on_date
-      t.string :receiving_location_code
-      t.string :vendor_code
-      t.string :update_count
-      t.integer :piece_count
-      t.string :e_check_in_code
-      t.string :media_type_code
-      t.date :updated_date
-      t.date :created_date
-      t.date :deleted_date
+      t.integer :bibIds, array: true, default: []
+      t.string :bibIdLinks, array: true, default: []
+      t.integer :itemIds, array: true, default: []
+      t.string :itemIdLinks, array: true, default: []
+      t.boolean :inheritLocation
+      t.string :allocationRule
+      t.integer :accountingUnit
+      t.string :labelCode
+      t.string :serialCode1
+      t.string :serialCode2
+      t.string :serialCode3
+      t.string :serialCode4
+      t.string :claimOnDate
+      t.string :receivingLocationCode
+      t.string :vendorCode
+      t.string :updateCount
+      t.integer :pieceCount
+      t.string :eCheckInCode
+      t.string :mediaTypeCode
+      t.date :updatedDate
+      t.date :createdDate
+      t.date :deletedDate
       t.boolean :deleted
       t.boolean :suppressed
-      t.jsonb :fixed_fields, default: {}
-      t.jsonb :var_fields, default: {}
+      t.jsonb :fixedFields, default: {}
+      t.jsonb :varFields, default: {}
       t.jsonb :holdings, default: {}
       t.jsonb :location, default: {}
-      t.jsonb :check_in_cards, default: {}
+      t.jsonb :checkInCards, default: {}
     end
   end
 end

--- a/spec/db_init.rb
+++ b/spec/db_init.rb
@@ -1,107 +1,75 @@
 require 'pg'
 require 'active_record'
 require_relative '../models/record'
+require_relative '../holding-schema'
 
-def init_db
+def create_test_db
   ActiveRecord::Schema.define do
     drop_table :records, if_exists: true
   end
 
-  ActiveRecord::Schema.define do
-    create_table :records do |t|
-      t.index :id, unique: true
-      t.integer :bib_ids, array: true, default: []
-      t.string :bib_id_links, array: true, default: []
-      t.integer :item_ids, array: true, default: []
-      t.string :item_id_links, array: true, default: []
-      t.boolean :inherit_location
-      t.string :allocation_rule
-      t.integer :accounting_unit
-      t.string :label_code
-      t.string :serial_code_1
-      t.string :serial_code_2
-      t.string :serial_code_3
-      t.string :serial_code_4
-      t.string :claim_on_date
-      t.string :receiving_location_code
-      t.string :vendor_code
-      t.string :update_count
-      t.integer :piece_count
-      t.string :e_check_in_code
-      t.string :media_type_code
-      t.date :updated_date
-      t.date :created_date
-      t.date :deleted_date
-      t.boolean :deleted
-      t.boolean :suppressed
-      t.jsonb :fixed_fields, default: {}
-      t.jsonb :var_fields, default: {}
-      t.jsonb :holdings, default: {}
-      t.jsonb :location, default: {}
-      t.jsonb :check_in_cards, default: {}
-    end
-  end
+  init_db
 
   record_1 = {
     "id"=>1,
-    "bib_ids"=>[1, 2, 3],
-    "bib_id_links"=>[],
-    "item_ids"=>[],
-    "item_id_links"=>[],
-    "inherit_location"=>nil,
-    "allocation_rule"=>nil,
-    "accounting_unit"=>1,
-    "label_code"=>"blah",
-    "serial_code_1"=>nil,
-    "serial_code_2"=>nil,
-    "serial_code_3"=>nil,
-    "serial_code_4"=>nil,
-    "claim_on_date"=>nil,
-    "receiving_location_code"=>nil,
-    "vendor_code"=>nil,
-    "update_count"=>nil,
-    "piece_count"=>nil,
-    "e_check_in_code"=>nil,
-    "media_type_code"=>nil,
-    "updated_date"=>nil,
-    "created_date"=>"2020-07-29",
-    "deleted_date"=>nil,
+    "bibIds"=>[1, 2, 3],
+    "bibIdLinks"=>[],
+    "itemIds"=>[],
+    "itemIdLinks"=>[],
+    "inheritLocation"=>nil,
+    "allocationRule"=>nil,
+    "accountingUnit"=>1,
+    "labelCode"=>"blah",
+    "serialCode1"=>nil,
+    "serialCode2"=>nil,
+    "serialCode3"=>nil,
+    "serialCode4"=>nil,
+    "claimOnDate"=>nil,
+    "receivingLocationCode"=>nil,
+    "vendorCode"=>nil,
+    "updateCount"=>nil,
+    "pieceCount"=>nil,
+    "eCheckInCode"=>nil,
+    "mediaTypeCode"=>nil,
+    "updatedDate"=>nil,
+    "createdDate"=>"2020-07-29",
+    "deletedDate"=>nil,
     "deleted"=>nil,
     "suppressed"=>nil,
-    "fixed_fields"=>{},
-    "var_fields"=>{},
+    "fixedFields"=>{},
+    "varFields"=>{},
     "holdings"=>{"a"=>1, "b"=>[2, 3]},
     "location"=>nil
   }
 
   record_2 = {
     "id"=>2,
-    "bib_ids"=>[3,4,5],
-    "bib_id_links"=>[],
-    "item_ids"=>[],
-    "item_id_links"=>[],
-    "inherit_location"=>nil,
-    "allocation_rule"=>nil,
-    "accounting_unit"=>1,
-    "label_code"=>"blah",
-    "serial_code_1"=>nil,
-    "serial_code_2"=>nil,
-    "serial_code_3"=>nil,
-    "serial_code_4"=>nil,
-    "claim_on_date"=>nil,
-    "receiving_location_code"=>nil,
-    "vendor_code"=>nil,
-    "update_count"=>nil,
-    "piece_count"=>nil,
-    "e_check_in_code"=>nil,
-    "media_type_code"=>nil,
-    "updated_date"=>nil,
-    "created_date"=>"2020-07-29",
-    "deleted_date"=>nil,
+    "bibIds"=>[3,4,5],
+    "bibIdLinks"=>[],
+    "itemIds"=>[],
+    "itemIdLinks"=>[],
+    "inheritLocation"=>nil,
+    "allocationRule"=>nil,
+    "accountingUnit"=>1,
+    "labelCode"=>"blah",
+    "serialCode1"=>nil,
+    "serialCode2"=>nil,
+    "serialCode3"=>nil,
+    "serialCode4"=>nil,
+    "claimOnDate"=>nil,
+    "receivingLocationCode"=>nil,
+    "vendorCode"=>nil,
+    "updateCount"=>nil,
+    "pieceCount"=>nil,
+    "eCheckInCode"=>nil,
+    "mediaTypeCode"=>nil,
+    "updatedDate"=>nil,
+    "createdDate"=>"2020-07-29",
+    "deletedDate"=>nil,
     "deleted"=>nil,
     "suppressed"=>nil,
-    "fixed_fields"=>{},
-    "var_fields"=>{},
+    "fixedFields"=>{},
+    "varFields"=>{},
     "holdings"=>{"a"=>1, "b"=>[2, 3]},
     "location"=>nil
   }

--- a/spec/functional/app_spec.rb
+++ b/spec/functional/app_spec.rb
@@ -60,7 +60,7 @@ describe 'HoldingService' do
     it "should update the record in case of old record" do
       expect_any_instance_of(NYPLRubyUtil::KinesisClient).to receive(:<<).with(JSON.parse(updated_correct_event["body"]).first)
       resp = handle_event(event: updated_correct_event, context: {})
-      expect(Record.find_by(id: 1140039).inherit_location).to eq(true)
+      expect(Record.find_by(id: 1140039).inheritLocation).to eq(true)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,8 @@ ActiveRecord::Base.establish_connection(
   host: ENV['DB_HOST'],
   username: ENV['DB_USERNAME']
 )
-init_db
+
+create_test_db
 
 class MockKinesisResponse
   def successful?

--- a/spec/unit/app_spec.rb
+++ b/spec/unit/app_spec.rb
@@ -25,10 +25,6 @@ describe 'app' do
             expect($logger.class).to eq(RSpec::Mocks::Double)
         end
         
-        it "should initialize db_fields" do
-            expect($db_fields.class).to eq(Hash)
-        end
-        
         it "should initialize kinesis_client" do
             expect($kinesis_client).to eq('mock_kinesis')
         end


### PR DESCRIPTION
This may be a bit unorthodox, but this converts the postgres column names to camelCase and updates this function to interact with this new schema. This is for three reasons:

- It aligns the Kinesis stream and API response for the holdings data to a single format
- It aligns the Holding stream with the Bib and Item streams and API responses
- It provides the fields in the format expected by the discovery store poster

To do so there are also some minor changes to the test suite and how queries are constructed when a `GET` request is received.

To deploy this we will have to make sure that the qa/production databases are updated to new schemas before deploying this function. (Ideally this would be done with an ActiveRecord migration, but that is overkill at the moment). So the procedure should be:

1) Temporarily disable the incoming Kinesis stream to the `HoldingPoster`
2) Manually update the table schema of the database
3) Deploy this new code to the function
4) Re-enable the Kinesis stream