### PR TITLE
Fix bug with ?bib_id= route

### DIFF
--- a/spec/unit/http_methods_spec.rb
+++ b/spec/unit/http_methods_spec.rb
@@ -19,8 +19,7 @@ describe HTTPMethods do
             string_params = {
                 'queryStringParameters' => {
                     'ids' => '1,2,3'
-                },
-                'pathParameters' => {}
+                }
             }
             expect(HTTPMethods).to receive(:get_holdings).with(string_params['queryStringParameters']).and_return('test_multi_holdings')
 

--- a/src/http_methods.rb
+++ b/src/http_methods.rb
@@ -6,7 +6,7 @@ class HTTPMethods
     $logger.info('handling GET request')
 
     params = event['queryStringParameters']
-    path_params = event['pathParameters']
+    path_params = event['pathParameters'] || {}
 
     if path_params.key? 'id'
       return get_holding(path_params['id'])


### PR DESCRIPTION
It looks like the HoldingsService in qa and production doesn't support GETing by bib_id. It looks like the method expects `pathParameters` to exist in the api gateway event, but that key appears to be `null` for requests without path params. That produces an internal error before attempting the query. Maybe AWS changed the "empty" form of `pathParameters` from `{}` to `null`..

I'm not certain this is the whole fix. Please weigh in