### PR TITLE
NOREF Improve query performance for bib_ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.0.3 - 2021-07-26
+### Added
+- Added holdings?bib_ids= route to handle queries for multiple bib_ids
+### Fix
+- Updated query on `bibIds` column to use GIN index
+
 ## 0.0.2 - 2021-07-09
 ### Fix
 - Fix holdings?bib_id= route https://github.com/NYPL-discovery/HoldingService/pull/33

--- a/spec/unit/http_methods_spec.rb
+++ b/spec/unit/http_methods_spec.rb
@@ -116,7 +116,7 @@ describe HTTPMethods do
         it 'should return 500 if query is unsuccessful' do
             test_params = { 'bib_id' => '1' }
             expect(HTTPMethods).to receive(:check_for_param_errors).with(test_params).and_return(nil)
-            expect(Record).to receive(:where).with('1 = ANY("bibIds")').and_raise(StandardError, 'Test Error')
+            expect(Record).to receive(:where).with('\'{1}\' && "bibIds"').and_raise(StandardError, 'Test Error')
             expect(HTTPMethods).to receive(:respond).with(500, 'problem getting records with query: 1 = ANY("bibIds"), message: Test Error').and_return(500)
 
             res = HTTPMethods.get_holdings(test_params)
@@ -147,7 +147,7 @@ describe HTTPMethods do
 
         it 'should return 400 error if bib_ids contains invalid characters' do
             expect(HTTPMethods).to receive(:respond).with(400, 'bib_ids must contain comma-delimited numerical values').and_return(400)
-            expect(HTTPMethods.check_for_param_errors({ 'bib_id' => '1,2,abc' })).to eq(400)
+            expect(HTTPMethods.check_for_param_errors({ 'bib_ids' => '1,2,abc' })).to eq(400)
         end
     end
 

--- a/spec/unit/http_methods_spec.rb
+++ b/spec/unit/http_methods_spec.rb
@@ -148,6 +148,7 @@ describe HTTPMethods do
         it 'should return 400 error if bib_ids contains invalid characters' do
             expect(HTTPMethods).to receive(:respond).with(400, 'bib_ids must contain comma-delimited numerical values').and_return(400)
             expect(HTTPMethods.check_for_param_errors({ 'bib_id' => '1,2,abc' })).to eq(400)
+        end
     end
 
     describe :post_holding do

--- a/spec/unit/http_methods_spec.rb
+++ b/spec/unit/http_methods_spec.rb
@@ -117,7 +117,7 @@ describe HTTPMethods do
             test_params = { 'bib_id' => '1' }
             expect(HTTPMethods).to receive(:check_for_param_errors).with(test_params).and_return(nil)
             expect(Record).to receive(:where).with('\'{1}\' && "bibIds"').and_raise(StandardError, 'Test Error')
-            expect(HTTPMethods).to receive(:respond).with(500, 'problem getting records with query: 1 = ANY("bibIds"), message: Test Error').and_return(500)
+            expect(HTTPMethods).to receive(:respond).with(500, 'problem getting records with query: \'{1}\' && "bibIds", message: Test Error').and_return(500)
 
             res = HTTPMethods.get_holdings(test_params)
 

--- a/src/http_methods.rb
+++ b/src/http_methods.rb
@@ -44,9 +44,9 @@ class HTTPMethods
     if params['ids']
       ids = params['ids']
       query = "id IN (#{ids})"
-    else
-      bib_id = params['bib_id']
-      query = "#{bib_id} = ANY(\"bibIds\")"
+    elsif params['bib_id'] || params['bib_ids']
+      bib_ids = params['bib_id'] || params['bib_ids']
+      query = "'{#{bib_ids}}' && \"bibIds\""
     end
 
     $logger.info("getting holdings by query: #{query}")
@@ -70,6 +70,8 @@ class HTTPMethods
       error_messages << "Can only have one of ids, bib_id"
     elsif params['bib_id'] && !params['bib_id'].match(/^\d+$/)
       error_messages << "bib_id must be a single numerical value"
+    elsif params['bib_ids'] && !params['bib_ids'].match(/^[\d\,]+$/)
+      error_messages << "bib_ids must contain comma-delimited numerical values"
     end
     if !error_messages.empty?
       return respond(400, error_messages.join(", "))


### PR DESCRIPTION
The handling of `bib_ids` in the holding service was not holding up to intensive bulk processing procedures, this PR is intended to strengthen this aspect of the service. Two things are added here:

- First the query against the `bibIds` column in the postgres db is changed from an `ANY` query to an array intersection query `&&` This allows the query to use a GIN index to improve performance
- It also means that a `bib_ids` parameter can be added to query multiple bib_ids at once. These must be structured as a comma-delimited list of integers

These two improvements should greatly improve performance by reducing the load on the holdings database.

After testing this in QA the GIN index must be added to the production database before deploying this code in production.